### PR TITLE
Cicd and project scaffolding

### DIFF
--- a/.black
+++ b/.black
@@ -1,0 +1,21 @@
+[tool.black]
+line-length = 79
+py36 = true
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | doc
+  | LICENSE
+  | Makefile
+  | MANIFEST.in
+  | README.md
+  | requirements.txt
+  | tox.ini
+)/
+'''

--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,0 +1,35 @@
+
+module.exports = {
+	rules: {
+		'body-leading-blank': [1, 'always'],
+		'footer-leading-blank': [1, 'always'],
+		'header-max-length': [2, 'always', 72],
+		'scope-case': [2, 'always', 'lower-case'],
+		'subject-case': [
+			2,
+			'never',
+			['sentence-case', 'start-case', 'pascal-case', 'upper-case']
+		],
+		'subject-empty': [2, 'never'],
+		'subject-full-stop': [2, 'never', '.'],
+		'type-case': [2, 'always', 'lower-case'],
+		'type-empty': [2, 'never'],
+		'type-enum': [
+			2,
+			'always',
+			[
+				'build',
+				'chore',
+				'ci',
+				'docs',
+				'feat',
+				'fix',
+				'perf',
+				'refactor',
+				'revert',
+				'style',
+				'test'
+			]
+		]
+	}
+};

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @tcaldron

--- a/.github/workflows/qa_and_unit_tests.yml
+++ b/.github/workflows/qa_and_unit_tests.yml
@@ -1,0 +1,40 @@
+
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 2
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Format with Black
+      run: |
+        pip install black
+        black --config .black
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        flake8 .
+    - name: Type Checking with MyPy
+      run: |
+        pip install mypy
+        mypy --ignore-missing-imports .
+    - name: Test with Tox
+      run: |
+        pip install tox pytest pytest-cov pytest-runner
+        tox

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "13.x"
+      - run: |
+          npm install -g semantic-release           \
+          "@semantic-release/changelog"             \
+          "@semantic-release/commit-analyzer"       \
+          "@semantic-release/git"                   \
+          "@semantic-release/release-notes-generator"
+          npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+default_stages: [commit, push]
+fail_fast: true
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+    -   id: detect-private-key
+    -   id: trailing-whitespace
+    -   id: check-merge-conflict
+    -   id: requirements-txt-fixer
+    -   id: detect-aws-credentials
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: '0c3b8045'
+    hooks:
+    -   id: flake8
+        exclude: (tests|script)
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    -   id: black
+        language_version: python3.8
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.770
+    hooks:
+    -   id: mypy
+        exclude: ^doc/
+-   repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v2.2.2
+    hooks:
+    -    id: commitlint
+         stages: [commit-msg]

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,22 @@
+{
+    "branch": "master",
+    "plugins": [
+        "@semantic-release/commit-analyzer",
+        "@semantic-release/release-notes-generator",
+        [
+            "@semantic-release/changelog",
+            {
+                "changelogFile": "CHANGELOG.md",
+                "changelogTitle": "# Changelog"
+            }
+        ],
+        [
+            "@semantic-release/github",
+            {
+                "assets": [
+                    "CHANGELOG.md"
+                    ]
+            }
+        ]
+    ]
+}

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,0 +1,66 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+
+# -- Project information -----------------------------------------------------
+
+project = "xmlscrape"
+copyright = "2020, Taylor Caldron"
+author = "Taylor Caldron"
+
+# The full version, including alpha/beta/rc tags
+release = "0.1.0"
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.autosectionlabel",
+    "sphinx.ext.coverage",
+    "sphinx.ext.doctest",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.todo",
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "alabaster"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]
+
+# Include TODOS in documentation.
+todo_include_todos = True

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,0 +1,19 @@
+.. tswf-api documentation master file, created by
+   sphinx-quickstart on Sat Jan 11 16:25:51 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to xmlscrape's documentation!
+====================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,35 @@
+import os
+from setuptools import setup, find_packages
+
+cwd = os.path.abspath(os.path.dirname(__file__))
+
+requires = [
+    "argparse",
+    "progress",
+    "lxml",
+    "bs4",
+    "xlsxwriter",
+    ]
+
+setup(
+    name="xmlscrape",
+    description="Extracts URLs from XML sitemaps located in the CWD.",
+    classifiers=[
+        "Development Status :: Pre-Alpha",
+        "Environment :: Web Environment",
+        "Intended Audience :: SEO",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Documentation :: Sphinx",
+    ],
+    author="@tcaldron",
+    url="https://github.com/tcaldron/xmlscrape",
+    keywords="xml sitemap scrape parse seo",
+    packages=find_packages(),
+    include_package_data=True,
+    zip_safe=False,
+    test_suite="xmlscrape",
+    setup_requires=["pytest-runner"],
+    tests_require=["pytest"],
+    install_requires=requires,
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,30 @@
+[tox]
+envlist = py36, py37, py38
+skip_missing_interpreters = true
+
+[testenv]
+
+install_command = pip install -U {opts} {packages}
+
+deps = pytest
+       -r {toxinidir}/requirements.txt
+       pytest-cov
+
+passenv = *
+setenv =
+    PYTHONPATH = {toxinidir}
+
+commands =
+	 python setup.py test
+
+
+[pytest]
+addopts = -s --cov . tests/ --cov-report term-missing --cov-fail-under=90 -p no:warnings
+
+
+[flake8]
+exclude = tests/, doc/
+ignore = E123, E203, E266, E501, W503
+max-line-length = 79
+max-complexity = 18
+select = B,C,E,F,W,T4,B9


### PR DESCRIPTION
## Whats in this Pull Request
* `.black` - this is a configuration file for [black](https://github.com/psf/black) which is a highly opinionated formatting tool.  It will re-format all of your code to follow PEP conventions (for the most part).

* `.commitlintrc.js` - this is a configuration file for a tool called [commitlint](https://github.com/conventional-changelog/commitlint) this tool essentially just makes sure that your commit messages adhere to something called [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).  the TL;DR of conventional commit is that it maps commit messages to the [semantic versioning](https://semver.org/) version scheme.

* `.github/CODEOWNERS` - this file declares what users owns what files in the repository.  It will enforce a requirement that any code owner is requested for review in pull requests.

* `.github/workflows/qa_and_unit_tests.yml` - this is a CICD pipeline for [Github Actions](https://github.com/features/actions) it will run all of the tools included in this PR for you automatically when a push is made to the repository.

* `.github/workflows/release.yml` - this is another CICD pipeline that only runs on your `master` branch.  It will create a release for you and put it in the *releases* page of the repository.  It will generate a CHANGELOG.md using your conventional commits as notes. *NOTE*: you need to generate a [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) and put it into your repository [secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)

* `.pre-commit-config.yaml` - this is a configuration file for a tool called [pre-commit](https://pre-commit.com/) it will enforce checks locally before commits and pushes to make sure you don't submit anything bad to the remote repository on Github.

* ` .releaserc` - this is a configuration file for the release pipeline that uses a [semantic-release](https://github.com/semantic-release/semantic-release)

* `doc/` - this directory contains scaffolding for [sphinx docs](https://www.sphinx-doc.org/en/master/) sphinx will pull out any comments in your code and format them into readable formatted text in a variety of formats--suitable for hosting as a webpage.

* `setup.cfg` & `setup.py` - these provide some configurations for testing, as well as metadata about your project.

* `tox.ini` - this file provides configurations for [tox](https://tox.readthedocs.io/en/latest/) which is a python unit testing framework.  it also provides configurations for [flake8](https://flake8.pycqa.org/en/latest/) which is another linting and styling tool.

each of the tools above can be used standalone, and don't necessarily have to be included as part of the repository or in CICD if you just want to check them out individually and see if they fit for you.

rather than merging in this entire PR, I'd just take a look at what sorts of things it provides scaffolding for, and use it for a reference when you're trying to automate more management aspects of your project.

Of all the tools mentioned, the most important is probably `tox`.  Whether you choose to use [unittest](https://docs.python.org/3/library/unittest.html), [pytest](https://docs.pytest.org/en/latest/), [nose](https://nose.readthedocs.io/en/latest/), or something else--unit testing will help make your project more stable and maintainable in the long run.